### PR TITLE
Added a "reversed order" option

### DIFF
--- a/autoload/place.vim
+++ b/autoload/place.vim
@@ -3,8 +3,13 @@
 "shouldRepeat = Whether or not to reuse values for dot repeat
 function! place#insert(shouldPrompt, shouldRepeat)
     if !a:shouldRepeat
-        let s:motion = place#get_motion()
-        let s:insertion = place#get_insertion(a:shouldPrompt)
+        if g:place_reversed
+            let s:insertion = place#get_insertion(a:shouldPrompt)
+            let s:motion = place#get_motion()
+        else
+            let s:motion = place#get_motion()
+            let s:insertion = place#get_insertion(a:shouldPrompt)
+        endif
         let s:mapping = place#get_type_for_motion(s:motion[0])
     endif
 

--- a/doc/place.txt
+++ b/doc/place.txt
@@ -14,6 +14,20 @@ place.vim - Place a character without moving
 
     `let g:place_blink = 0`
 
+`g:place_reversed`
+(default '0')
+
+    By default, place.vim takes a motion followed by character(s) to insert.
+    This option reverses things so that the motion goes last.
+
+    For example, to add a semicolon to the end of the line,
+    Default: `ga$;`, mnemonically "place, at end of line, a semicolon"
+    Reversed: `ga;$`, mnemonically "place semicolon at end of line"
+
+    To enable this option, set it to a value other than 0.
+
+    `let g:place_reversed = 1`
+
 ===============================================================================
 2. Mapping                                                       *place-mappings*
 

--- a/plugin/place.vim
+++ b/plugin/place.vim
@@ -1,4 +1,5 @@
 let g:place_blink = get(g:, 'place_blink', 1)
+let g:place_reversed = get(g:, 'place_reversed', 0)
 
 nnoremap <silent> <Plug>(place-insert) :<C-U>call place#insert(0,0)<cr>
 nnoremap <silent> <Plug>(place-insert-multiple) :<C-U>call place#insert(1,0)<cr>


### PR DESCRIPTION
I came up with this because I'm somewhat obsessed with mnemonics, and the default ordering of {motion}{insert-char} was somewhat unintuitive for me, especially when thinking verbally (e.g. "send, to EOL, a semicolon").

Feel free to take it or leave it, because I might be the sole user of the option forever. :P